### PR TITLE
LTS-11.x

### DIFF
--- a/dmcc-ws/Main.hs
+++ b/dmcc-ws/Main.hs
@@ -77,7 +77,7 @@ type AgentMap = TMVar (Map.Map AgentHandle Int)
 
 
 -- | Read config and actually start the server
-realMain :: (MonadLoggerIO m, MonadMask m, MonadBaseControl IO m)
+realMain :: (MonadUnliftIO m, MonadLoggerIO m, MonadMask m, MonadBaseControl IO m)
          => (m () -> IO ())
          -> FilePath
          -> m ()
@@ -128,7 +128,7 @@ realMain logger config = do
 
 -- | Decrement reference counter for an agent. If no references left,
 -- release control over agent. Return how many references are left.
-releaseAgentRef :: (MonadLoggerIO m, MonadMask m, MonadBaseControl IO m)
+releaseAgentRef :: (MonadUnliftIO m, MonadLoggerIO m, MonadMask m, MonadBaseControl IO m)
                 => AgentHandle -> AgentMap -> m Int
 releaseAgentRef ah refs = do
   r <- atomically $ takeTMVar refs
@@ -148,7 +148,7 @@ releaseAgentRef ah refs = do
       Nothing -> error $ "Releasing unknown agent " <> show ah
 
 
-avayaApplication :: (MonadLoggerIO m, MonadMask m, MonadBaseControl IO m)
+avayaApplication :: (MonadUnliftIO m, MonadLoggerIO m, MonadMask m, MonadBaseControl IO m)
                  => Config
                  -> Session
                  -- ^ DMCC session.

--- a/package.yaml
+++ b/package.yaml
@@ -32,11 +32,14 @@ dependencies:
   - bytestring
   - classy-prelude
   - containers
+  - monad-control
   - monad-logger
+  - safe-exceptions
   - stm
-  - stm-lifted
   - text
   - time
+  - transformers-base
+  - unliftio
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ ghc-options:
   - -Wall
   - -Wcompat
   - -Werror
+  - -Wno-missing-home-modules # fix for haddock (probably caused by *-boot files)
 
 dependencies:
   - aeson

--- a/src/DMCC/Agent.hs-boot
+++ b/src/DMCC/Agent.hs-boot
@@ -6,7 +6,6 @@ where
 
 import           DMCC.Prelude
 
-import           Control.Concurrent.STM.Lifted (TChan)
 import           Data.Text (Text)
 
 import           DMCC.Types
@@ -26,4 +25,5 @@ monitorId :: Agent -> Text
 rspChan :: Agent -> TChan Rs.Response
 
 
-releaseAgent :: (MonadLoggerIO m, MonadBaseControl IO m, MonadCatch m) => AgentHandle -> m ()
+releaseAgent :: (MonadUnliftIO m, MonadLoggerIO m, MonadBaseControl IO m, MonadCatch m)
+             => AgentHandle -> m ()

--- a/src/DMCC/Prelude.hs
+++ b/src/DMCC/Prelude.hs
@@ -2,7 +2,12 @@
 
 module DMCC.Prelude
   ( module ClassyPrelude
-  , module Control.Concurrent.STM.Lifted
+  , module UnliftIO.IO
+  , module UnliftIO.STM
+  , module UnliftIO.Concurrent
+  , module Control.Monad.Base
+  , module Control.Monad.Trans.Control
+  , module Control.Exception.Safe
   , module Control.Monad.Logger
   )
 
@@ -17,6 +22,15 @@ import ClassyPrelude hiding ( atomically
                             , newTQueueIO
                             , newTVarIO
                             , readTVarIO
+                            , mkWeakTVar
+                            , mkWeakTMVar
+                            , registerDelay
                             )
-import Control.Concurrent.STM.Lifted
+
+import UnliftIO.IO
+import UnliftIO.STM
+import UnliftIO.Concurrent
+import Control.Monad.Base (MonadBase)
+import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Exception.Safe (MonadThrow, MonadCatch, MonadMask)
 import Control.Monad.Logger

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,2 @@
-resolver: lts-9.21
-extra-deps:
-  - stm-lifted-0.1.1.0
-packages:
-  - '.'
+resolver: lts-11.6
+packages: ['.']


### PR DESCRIPTION
Включает себя всё, что делалось по **LTS-9.x**, в качестве base ветки указан **LTS-9.x** чтобы видеть разницу конкретно для **LTS-11.x**.

Также избавился от эксплиситной зависимости от `stm-lifted`, заменив на `unliftio` (который уже подключается в `classy-prelude`).